### PR TITLE
NINEDOCS-84 User 도메인으로부터 4xx / 5xx 에러 응답 수신 시 로깅

### DIFF
--- a/src/main/java/com/ninedocs/serviceaggregator/client/common/error/ApiErrorException.java
+++ b/src/main/java/com/ninedocs/serviceaggregator/client/common/error/ApiErrorException.java
@@ -1,0 +1,18 @@
+package com.ninedocs.serviceaggregator.client.common.error;
+
+import java.net.URI;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+
+@Builder
+@RequiredArgsConstructor
+@Getter
+public class ApiErrorException extends RuntimeException {
+
+  private final String domainName;
+  private final URI requestUri;
+  private final HttpStatusCode statusCode;
+  private final String reason;
+}

--- a/src/main/java/com/ninedocs/serviceaggregator/controller/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/ninedocs/serviceaggregator/controller/common/GlobalExceptionHandler.java
@@ -1,13 +1,15 @@
 package com.ninedocs.serviceaggregator.controller.common;
 
+import com.ninedocs.serviceaggregator.client.common.error.ApiErrorException;
 import com.ninedocs.serviceaggregator.controller.common.exception.CustomException;
 import com.ninedocs.serviceaggregator.controller.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -16,8 +18,12 @@ public class GlobalExceptionHandler {
     return Mono.just(ResponseEntity.ok(ApiResponse.error(e.getErrorCode())));
   }
 
-  @ExceptionHandler(ResponseStatusException.class)
-  public ResponseEntity<String> handleResponseStatusException(ResponseStatusException e) {
+  @ExceptionHandler(ApiErrorException.class)
+  public ResponseEntity<String> handleResponseStatusException(ApiErrorException e) {
+    log.error(
+        "# {} 도메인에 {} 요청 시 {} Error 발생 : {}",
+        e.getDomainName(), e.getRequestUri().getPath(), e.getStatusCode(), e.getReason()
+    );
     return ResponseEntity
         .status(e.getStatusCode())
         .body(e.getReason());


### PR DESCRIPTION
# Description
User 도메인으로 API 요청했을 때
4xx 또는 5xx 응답을 받을 경우
다음과 같은 message 로 ERROR Level 로그를 남기도록 구현
- 형식
  `# User 도메인에 <URI Path> 요청 시 <ERROR Status Code> 발생 : <User로부터 수신한 에러메세지>`
- 예시
  ```
  # User 도메인에 /api/v1/user/email-verification-code 요청 시 500 INTERNAL_SERVER_ERROR Error 발생 : No message available
  ```