### PR TITLE
NINEDOCS-192, NINEDOCS-194 base image 변경

### DIFF
--- a/cicd/DockerfileWithoutBuild
+++ b/cicd/DockerfileWithoutBuild
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.13-alpine3.20
+FROM kiel0103/ninedocs-jdk-base:v1
 
 COPY *.jar app.jar
 

--- a/cicd/Jenkinsfile
+++ b/cicd/Jenkinsfile
@@ -55,38 +55,42 @@ pipeline {
                 }
             }
         }
-        stage("Docker Build") {
-            steps {
-                sh "docker build -t $DOCKER_HUB_IMAGE_REPO -f cicd/DockerfileWithoutBuild build/libs"
-            }
-            post {
-                success {
-                    sh 'echo "# docker build success"'
-                }
-                failure {
-                    sh 'echo "# docker build failure"'
-                }
-            }
-        }
-        stage("Push Image") {
+        stage("Docker Image Build and Push") {
             environment {
                 DOCKER_HUB_CREDENTIAL = credentials('yerim_dockerhub')
             }
             steps {
-                sh "echo $DOCKER_HUB_CREDENTIAL_PSW | docker login -u $DOCKER_HUB_CREDENTIAL_USR --password-stdin"
-                sh "docker tag $DOCKER_HUB_IMAGE_REPO $DOCKER_HUB_CREDENTIAL_USR/$DOCKER_HUB_IMAGE_REPO:${env.TAG}"
-                sh "docker push $DOCKER_HUB_CREDENTIAL_USR/$DOCKER_HUB_IMAGE_REPO:${env.TAG}"
-                sh "docker logout"
+//                 sh "docker build -t $DOCKER_HUB_IMAGE_REPO -f cicd/DockerfileWithoutBuild build/libs"
+                sh "docker buildx build --platform linux/amd64,linux/arm64 -t $DOCKER_HUB_CREDENTIAL_USR/$DOCKER_HUB_IMAGE_REPO:${env.TAG} -f cicd/DockerfileWithoutBuild build/libs --push"
             }
             post {
                 success {
-                    sh 'echo "# image push success"'
+                    sh 'echo "# docker build and push success"'
                 }
                 failure {
-                    sh 'echo "# image push failure"'
+                    sh 'echo "# docker build and push failure"'
                 }
             }
         }
+//         stage("Push Image") {
+//             environment {
+//                 DOCKER_HUB_CREDENTIAL = credentials('yerim_dockerhub')
+//             }
+//             steps {
+//                 sh "echo $DOCKER_HUB_CREDENTIAL_PSW | docker login -u $DOCKER_HUB_CREDENTIAL_USR --password-stdin"
+//                 sh "docker tag $DOCKER_HUB_IMAGE_REPO $DOCKER_HUB_CREDENTIAL_USR/$DOCKER_HUB_IMAGE_REPO:${env.TAG}"
+//                 sh "docker push $DOCKER_HUB_CREDENTIAL_USR/$DOCKER_HUB_IMAGE_REPO:${env.TAG}"
+//                 sh "docker logout"
+//             }
+//             post {
+//                 success {
+//                     sh 'echo "# image push success"'
+//                 }
+//                 failure {
+//                     sh 'echo "# image push failure"'
+//                 }
+//             }
+//         }
         stage('Update Helm values.yaml') {
             steps {
                 script {


### PR DESCRIPTION
## 문제 상황
기존에 base image를 amazoncorretto docker hub의 tag = "17.0.13-alpine3.20" 를 사용하고 있었다.
그런데 amazoncorretto 에서 이 태그에 해당하는 이미지를 없애버린 듯. (지금 찾아보면 없음)

여태까지는 Jenkins 에 캐시되어있던걸 사용하고 있었어서 문제 없었는데,
이후 Jenkins 에서 docker 캐시가 날아가면서
원격에 이미지가 없어진게 반영되어 빌드에 실패함

## 해결
- 이미지 교체
- 원격 이미지를 직접 base image 로 사용하지 않고, 다운받아서 내 원격에 올린다음 그걸 base image 로 사용